### PR TITLE
FIX: Show location list after cscope is called.

### DIFF
--- a/plugin/cscope.vim
+++ b/plugin/cscope.vim
@@ -318,7 +318,7 @@ function! CscopeFind(action, word)
   let dbl = <SID>AutoloadDB(expand('%:p:h'))
   if dbl == 0
     try
-      exe ':lcs f '.a:action.' '.a:word
+      exe ':cs f '.a:action.' '.a:word
       if g:cscope_open_location == 1
         lw
       endif


### PR DESCRIPTION
When using lcs on my vim setup, the location list is not shown, and the navigation goes to the first result. This can be misleading when multiple locations exists for one query.